### PR TITLE
Add black, flake8, and isort to tztrout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,14 @@ workflows:
     jobs:
       - test-3.5
 
+setup:
+  - &lint
+    run:
+      name: Run flake8
+      command: |
+        flake8
+        isort -rc -c .
+        
 defaults: &defaults
   working_directory: ~/code
   steps:
@@ -13,6 +21,10 @@ defaults: &defaults
   - run:
       name: Install dependencies
       command: pip install -r requirements.txt
+  - run:
+      name: Install flake8 and isort
+      command: pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming isort
+  - *lint
   - run:
       name: Test
       command: PYTHONPATH=. python tests/__init__.py

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,14 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-3.5
+      - test-3.6
 
 setup:
   - &lint
     run:
       name: Run flake8
       command: |
+        black --check .
         flake8
         isort -rc -c .
         
@@ -22,15 +23,15 @@ defaults: &defaults
       name: Install dependencies
       command: pip install -r requirements.txt
   - run:
-      name: Install flake8 and isort
-      command: pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming isort
+      name: Install black flake8 and isort
+      command: pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming isort black==19.10b0
   - *lint
   - run:
       name: Test
       command: PYTHONPATH=. python tests/__init__.py
 
 jobs:
-  test-3.5:
+  test-3.6:
     <<: *defaults
     docker:
-    - image: circleci/python:3.5
+    - image: circleci/python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,24 @@
 version: 2
+
+workflows:
+  version: 2
+  workflow:
+    jobs:
+      - test-3.5
+
+defaults: &defaults
+  working_directory: ~/code
+  steps:
+  - checkout
+  - run:
+      name: Install dependencies
+      command: pip install -r requirements.txt
+  - run:
+      name: Test
+      command: PYTHONPATH=. python tests/__init__.py
+
 jobs:
-  build:
+  test-3.5:
+    <<: *defaults
     docker:
-      - image: circleci/python:3.5.7
-    steps:
-      - checkout
-      - run: virtualenv venv
-      - run: venv/bin/pip install -r requirements.txt
-      - run: PYTHONPATH=. venv/bin/python tests/__init__.py
+    - image: circleci/python:3.5

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,13 @@ defaults: &defaults
   steps:
   - checkout
   - run:
-      name: Install dependencies
-      command: pip install -r requirements.txt
-  - run:
       name: Install black flake8 and isort
       command: pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming isort black==19.10b0
   - *lint
+  - run:
+      name: Install dependencies
+      command: pip install -r requirements.txt
+  
   - run:
       name: Test
       command: PYTHONPATH=. python tests/__init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,6 @@ line-length = 79
 exclude = '''
 /(
   \.git
+  | \.eggs
 )/
 '''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.black]
+skip-string-normalization = true
+line-length = 79
+exclude = '''
+/(
+  \.git
+)/
+'''

--- a/regenerate_data.py
+++ b/regenerate_data.py
@@ -5,9 +5,10 @@ Commit changes after the run.
 """
 import sys
 
+from tztrout import td
+
 sys.path.append('.')
 
-from tztrout import td
 
 if __name__ == '__main__':
     td.generate_tz_name_to_tz_id_map()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [flake8]
 exclude=build,dist,venv,.tox,.eggs
-ignore=D1,D200,D202,D204,D205,D40,E127,E128,E226,F403,F405,I100,N806
+ignore=D1,D200,D202,D204,D205,D40,E127,E128,E226,E231,E731,F403,F405,I100,N806,W503,W504
 import-order-style=google
-max-complexity=12
-max-line-length = 80
+max-complexity=14
+max-line-length=119
 
 [isort]
 skip=.tox,venv

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[flake8]
+exclude=dist,venv,.tox,.eggs
+ignore=D1,D200,D202,D204,D205,D40,E127,E128,E226,F403,F405,I100,N806
+import-order-style=google
+max-complexity=12
+max-line-length = 80
+
+[isort]
+skip=.tox,venv
+not_skip=__init__.py
+known_first_party=tztrout
+known_tests=tests
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER
+default_section=THIRDPARTY
+use_parentheses=true
+multi_line_output=5

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-exclude=dist,venv,.tox,.eggs
+exclude=build,dist,venv,.tox,.eggs
 ignore=D1,D200,D202,D204,D205,D40,E127,E128,E226,F403,F405,I100,N806
 import-order-style=google
 max-complexity=12

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ],
-    packages=[
-        'tztrout',
-    ],
-    package_data={
-        'tztrout': ['data/*']
-    },
+    packages=['tztrout',],
+    package_data={'tztrout': ['data/*']},
     install_requires=[
         'phonenumbers>=8.3.0',
         'python-dateutil',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,9 @@
 import datetime
-import tztrout
 import unittest
 
 from mock import patch
+
+import tztrout
 
 
 class FakeDateTime(datetime.datetime):
@@ -12,7 +13,9 @@ class FakeDateTime(datetime.datetime):
     def utcnow(cls, *args, **kwargs):
         if hasattr(cls, 'dt'):
             return cls.dt
-        raise NotImplementedError('use FakeDateTime.set_utcnow(datetime) first')
+        raise NotImplementedError(
+            'use FakeDateTime.set_utcnow(datetime) first'
+        )
 
     @classmethod
     def set_utcnow(cls, dt):
@@ -20,7 +23,6 @@ class FakeDateTime(datetime.datetime):
 
 
 class TZTroutTestCase(unittest.TestCase):
-
     def test_ids_for_phone(self):
         ids = tztrout.tz_ids_for_phone('+1 (650) 333 4444')
         self.assertEqual(ids, ['America/Los_Angeles'])
@@ -73,7 +75,9 @@ class TZTroutTestCase(unittest.TestCase):
         self.assertTrue('America/New_York' in ids)
 
     def test_ids_for_address_with_zipcode(self):
-        ids = tztrout.tz_ids_for_address('US', state='California', zipcode='94041')
+        ids = tztrout.tz_ids_for_address(
+            'US', state='California', zipcode='94041'
+        )
         self.assertEqual(ids, ['America/Los_Angeles'])
         ids = tztrout.tz_ids_for_address('US', zipcode='94041')
         self.assertEqual(ids, ['America/Los_Angeles'])
@@ -104,7 +108,7 @@ class TZTroutTestCase(unittest.TestCase):
             u'America/Vancouver',
             u'America/Whitehorse',
             u'Canada/Pacific',
-            u'US/Pacific'
+            u'US/Pacific',
         ]
         ids = tztrout.tz_ids_for_tz_name('PT')
         self.assertEqual(ids, pacific_ids)
@@ -128,75 +132,79 @@ class TZTroutTestCase(unittest.TestCase):
     @patch('datetime.datetime', FakeDateTime)
     def test_offset_ranges_for_9_to_5(self):
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1, 20))  # 8 pm UTC
-        offset_ranges = tztrout.offset_ranges_for_local_time(datetime.time(9), datetime.time(17))
-        self.assertEqual(offset_ranges, [
-            [-11 * 60, -3 * 60],
-            [13 * 60, 14 * 60]
-        ])
+        offset_ranges = tztrout.offset_ranges_for_local_time(
+            datetime.time(9), datetime.time(17)
+        )
+        self.assertEqual(
+            offset_ranges, [[-11 * 60, -3 * 60], [13 * 60, 14 * 60]]
+        )
 
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1))  # 12am UTC
-        offset_ranges = tztrout.offset_ranges_for_local_time(datetime.time(9), datetime.time(17))
-        self.assertEqual(offset_ranges, [
-            [9 * 60, 14 * 60],
-            [-14 * 60, -7 * 60]
-        ])
+        offset_ranges = tztrout.offset_ranges_for_local_time(
+            datetime.time(9), datetime.time(17)
+        )
+        self.assertEqual(
+            offset_ranges, [[9 * 60, 14 * 60], [-14 * 60, -7 * 60]]
+        )
 
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1, 4))  # 4am UTC
-        offset_ranges = tztrout.offset_ranges_for_local_time(datetime.time(9), datetime.time(17))
-        self.assertEqual(offset_ranges, [
-            [5 * 60, 13 * 60],
-            [-14 * 60, -11 * 60]
-        ])
+        offset_ranges = tztrout.offset_ranges_for_local_time(
+            datetime.time(9), datetime.time(17)
+        )
+        self.assertEqual(
+            offset_ranges, [[5 * 60, 13 * 60], [-14 * 60, -11 * 60]]
+        )
 
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1, 7))  # 7am UTC
-        offset_ranges = tztrout.offset_ranges_for_local_time(datetime.time(9), datetime.time(17))
-        self.assertEqual(offset_ranges, [
-            [2 * 60, 10 * 60],
-        ])
+        offset_ranges = tztrout.offset_ranges_for_local_time(
+            datetime.time(9), datetime.time(17)
+        )
+        self.assertEqual(offset_ranges, [[2 * 60, 10 * 60],])
 
     @patch('datetime.datetime', FakeDateTime)
     def test_offset_ranges_for_5_to_9(self):
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1, 20))  # 8 pm UTC
-        offset_ranges = tztrout.offset_ranges_for_local_time(datetime.time(17), datetime.time(9))
-        self.assertEqual(offset_ranges, [
-            [-3 * 60, 13 * 60],
-            [-14 * 60, -11 * 60]
-        ])
+        offset_ranges = tztrout.offset_ranges_for_local_time(
+            datetime.time(17), datetime.time(9)
+        )
+        self.assertEqual(
+            offset_ranges, [[-3 * 60, 13 * 60], [-14 * 60, -11 * 60]]
+        )
 
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1))  # 12am UTC
-        offset_ranges = tztrout.offset_ranges_for_local_time(datetime.time(17), datetime.time(9))
-        self.assertEqual(offset_ranges, [
-            [-7 * 60, 9 * 60],
-        ])
+        offset_ranges = tztrout.offset_ranges_for_local_time(
+            datetime.time(17), datetime.time(9)
+        )
+        self.assertEqual(offset_ranges, [[-7 * 60, 9 * 60],])
 
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1, 4))  # 4am UTC
-        offset_ranges = tztrout.offset_ranges_for_local_time(datetime.time(17), datetime.time(9))
-        self.assertEqual(offset_ranges, [
-            [13 * 60, 14 * 60],
-            [-11 * 60, 5 * 60]
-        ])
+        offset_ranges = tztrout.offset_ranges_for_local_time(
+            datetime.time(17), datetime.time(9)
+        )
+        self.assertEqual(
+            offset_ranges, [[13 * 60, 14 * 60], [-11 * 60, 5 * 60]]
+        )
 
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1, 7))  # 7am UTC
-        offset_ranges = tztrout.offset_ranges_for_local_time(datetime.time(17), datetime.time(9))
-        self.assertEqual(offset_ranges, [
-            [10 * 60, 14 * 60],
-            [-14 * 60, 2 * 60]
-        ])
+        offset_ranges = tztrout.offset_ranges_for_local_time(
+            datetime.time(17), datetime.time(9)
+        )
+        self.assertEqual(
+            offset_ranges, [[10 * 60, 14 * 60], [-14 * 60, 2 * 60]]
+        )
 
     @patch('datetime.datetime', FakeDateTime)
     def test_offset_ranges_for_parsed_time(self):
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1, 20))  # 8 pm UTC
         offset_ranges = tztrout.offset_ranges_for_local_time('9am', '5 pm')
-        self.assertEqual(offset_ranges, [
-            [-11 * 60, -3 * 60],
-            [13 * 60, 14 * 60]
-        ])
+        self.assertEqual(
+            offset_ranges, [[-11 * 60, -3 * 60], [13 * 60, 14 * 60]]
+        )
 
         offset_ranges = tztrout.offset_ranges_for_local_time('9:00', '17:00')
-        self.assertEqual(offset_ranges, [
-            [-11 * 60, -3 * 60],
-            [13 * 60, 14 * 60]
-        ])
+        self.assertEqual(
+            offset_ranges, [[-11 * 60, -3 * 60], [13 * 60, 14 * 60]]
+        )
 
     def test_wisconsin(self):
         """ Make sure WI is not counted as part of ET. """
@@ -218,7 +226,9 @@ class TZTroutTestCase(unittest.TestCase):
         tz_names.remove(tz_name)
         self.assertTrue(set(tztrout.tz_ids_for_tz_name(tz_name)) & set(ids))
         for other_name in tz_names:
-            self.assertFalse(set(tztrout.tz_ids_for_tz_name(other_name)) & set(ids))
+            self.assertFalse(
+                set(tztrout.tz_ids_for_tz_name(other_name)) & set(ids)
+            )
 
     def test_texas(self):
         """ Make sure TX is not counted as part of ET. """
@@ -316,7 +326,9 @@ class TZTroutTestCase(unittest.TestCase):
         self.assert_only_one_us_tz(ids, 'ET')
 
         # San Francisco
-        ids = tztrout.tz_ids_for_address('US', state='CA', city='San Francisco')
+        ids = tztrout.tz_ids_for_address(
+            'US', state='CA', city='San Francisco'
+        )
         ids2 = tztrout.tz_ids_for_phone('+14153334444')
         self.assertEqual(ids, ids2)
         self.assert_only_one_us_tz(ids, 'PT')
@@ -438,13 +450,22 @@ class TZTroutTestCase(unittest.TestCase):
     def test_canada_without_state_info(self):
         ids = tztrout.tz_ids_for_address('CA')
         expected_ids = [
-            "America/Whitehorse", "America/Vancouver", "America/Yellowknife",
-            "America/Edmonton", "America/Regina", "America/Winnipeg",
-            "America/Iqaluit", "America/Toronto", #"America/Montreal", TODO re-add Montreal when pytz.country_timezones is fixed
-            "America/Moncton", "America/Halifax", "America/St_Johns"
+            "America/Whitehorse",
+            "America/Vancouver",
+            "America/Yellowknife",
+            "America/Edmonton",
+            "America/Regina",
+            "America/Winnipeg",
+            "America/Iqaluit",
+            "America/Toronto",  # "America/Montreal", TODO re-add Montreal when pytz.country_timezones is fixed
+            "America/Moncton",
+            "America/Halifax",
+            "America/St_Johns",
         ]
         for tz_id in expected_ids:
-            self.assertTrue(tz_id in ids, tz_id + ' not present in the expected ids set')
+            self.assertTrue(
+                tz_id in ids, tz_id + ' not present in the expected ids set'
+            )
 
     def assert_only_one_au_tz(self, ids, tz_name):
         """ Assert that a given set of timezone ids only matches one tz name
@@ -455,7 +476,9 @@ class TZTroutTestCase(unittest.TestCase):
         tz_names.remove(tz_name)
         self.assertTrue(set(tztrout.tz_ids_for_tz_name(tz_name)) & set(ids))
         for other_name in tz_names:
-            self.assertFalse(set(tztrout.tz_ids_for_tz_name(other_name)) & set(ids))
+            self.assertFalse(
+                set(tztrout.tz_ids_for_tz_name(other_name)) & set(ids)
+            )
 
     def test_major_cities_australia(self):
 
@@ -584,22 +607,32 @@ class TZTroutTestCase(unittest.TestCase):
 
     def test_australia_without_state_info(self):
         ids = tztrout.tz_ids_for_address('AU')
-        expected_ids = ["Australia/Sydney", "Australia/Perth", "Australia/Darwin",
-            "Australia/Adelaide", "Australia/Darwin", "Australia/Adelaide",
-            "Australia/Hobart", "Australia/Melbourne", "Australia/Sydney",
-            "Australia/Brisbane"
+        expected_ids = [
+            "Australia/Sydney",
+            "Australia/Perth",
+            "Australia/Darwin",
+            "Australia/Adelaide",
+            "Australia/Darwin",
+            "Australia/Adelaide",
+            "Australia/Hobart",
+            "Australia/Melbourne",
+            "Australia/Sydney",
+            "Australia/Brisbane",
         ]
         for tz_id in expected_ids:
-            self.assertTrue(tz_id in ids, tz_id + ' not present in the expected ids set')
+            self.assertTrue(
+                tz_id in ids, tz_id + ' not present in the expected ids set'
+            )
 
     @patch('datetime.datetime', FakeDateTime)
     def test_local_time_in_spain(self):
         """Make sure local time is properly calculated for Spain."""
-        FakeDateTime.set_utcnow(datetime.datetime(2016, 9, 13, 22, 15))  # 15:15 PT / 22:15 UTC / 00:15 CEST
+        FakeDateTime.set_utcnow(
+            datetime.datetime(2016, 9, 13, 22, 15)
+        )  # 15:15 PT / 22:15 UTC / 00:15 CEST
         local_time = tztrout.local_time_for_address('ES', city='Barcelona')
         self.assertEqual(str(local_time), '2016-09-14 00:15:00+02:00')
 
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,7 +7,7 @@ import tztrout
 
 
 class FakeDateTime(datetime.datetime):
-    "A datetime replacement that lets you set utcnow()"
+    """A datetime replacement that lets you set utcnow()"""
 
     @classmethod
     def utcnow(cls, *args, **kwargs):
@@ -207,7 +207,7 @@ class TZTroutTestCase(unittest.TestCase):
         )
 
     def test_wisconsin(self):
-        """ Make sure WI is not counted as part of ET. """
+        """Make sure WI is not counted as part of ET."""
 
         ids = tztrout.tz_ids_for_address('US', state='WI')
         ids2 = tztrout.tz_ids_for_address('US', state='Wisconsin')
@@ -218,7 +218,7 @@ class TZTroutTestCase(unittest.TestCase):
         self.assert_only_one_us_tz(ids, 'CT')
 
     def assert_only_one_us_tz(self, ids, tz_name):
-        """ Assert that a given set of timezone ids only matches one tz name
+        """Assert that a given set of timezone ids only matches one tz name
         in North America.
         """
         tz_names = ['PT', 'MT', 'CT', 'ET', 'AT']
@@ -231,7 +231,7 @@ class TZTroutTestCase(unittest.TestCase):
             )
 
     def test_texas(self):
-        """ Make sure TX is not counted as part of ET. """
+        """Make sure TX is not counted as part of ET."""
 
         ids = tztrout.tz_ids_for_address('US', state='TX')
         ids2 = tztrout.tz_ids_for_address('US', state='Texas')
@@ -242,8 +242,9 @@ class TZTroutTestCase(unittest.TestCase):
         self.assert_only_one_us_tz(ids, 'CT')
 
     def test_major_cities_us(self):
-        """ Make sure all the major cities match the right time zone (and the
-        right time zone only). """
+        """Make sure all the major cities match the right time zone (and the
+        right time zone only).
+        """
 
         # New York
         ids = tztrout.tz_ids_for_address('US', state='NY', city='New York')
@@ -382,8 +383,9 @@ class TZTroutTestCase(unittest.TestCase):
         self.assert_only_one_us_tz(ids2, 'ET')
 
     def test_major_cities_canada(self):
-        """ Make sure all the major cities match the right time zone (and the
-        right time zone only). """
+        """Make sure all the major cities match the right time zone (and the
+        right time zone only).
+        """
 
         # Toronto, Ontario
         ids = tztrout.tz_ids_for_address('CA', state='ON', city='Toronto')
@@ -468,7 +470,7 @@ class TZTroutTestCase(unittest.TestCase):
             )
 
     def assert_only_one_au_tz(self, ids, tz_name):
-        """ Assert that a given set of timezone ids only matches one tz name
+        """Assert that a given set of timezone ids only matches one tz name
         in Australia.
         """
         tz_names = ['AWT', 'ACT', 'AET']

--- a/tztrout/__init__.py
+++ b/tztrout/__init__.py
@@ -68,7 +68,7 @@ def tz_ids_for_phone(phone, country='US'):
 
     try:
         phone = phonenumbers.parse(phone, country)
-    except:
+    except Exception:
         pass
     else:
         country_iso = phonenumbers.region_code_for_number(phone)

--- a/tztrout/__init__.py
+++ b/tztrout/__init__.py
@@ -13,13 +13,13 @@ td = TroutData()
 
 
 def _dedupe_preserve_ord(lst):
-    """ Dedupe a list and preserve the order of its items. """
+    """Dedupe a list and preserve the order of its items."""
     seen = set()
     return [x for x in lst if x not in seen and not seen.add(x)]
 
 
 def tz_ids_for_tz_name(tz_name):
-    """ Get the TZ identifiers that are currently in a specific time zone, e.g.
+    """Get the TZ identifiers that are currently in a specific time zone, e.g.
 
     >>> tztrout.tz_ids_for_tz_name('PDT')  # ran during DST
     [
@@ -56,7 +56,7 @@ def tz_ids_for_tz_name(tz_name):
 
 
 def tz_ids_for_phone(phone, country='US'):
-    """ Get the TZ identifiers that a phone number might be related to, e.g.
+    """Get the TZ identifiers that a phone number might be related to, e.g.
 
     >>> tztrout.tz_ids_for_phone('+16503334444')
     [u'America/Los_Angeles']
@@ -117,7 +117,7 @@ def tz_ids_for_phone(phone, country='US'):
 
 
 def tz_ids_for_address(country, state=None, city=None, zipcode=None, **kwargs):
-    """ Get the TZ identifiers for a given address, e.g.:
+    """Get the TZ identifiers for a given address, e.g.:
 
     >>> tztrout.tz_ids_for_address('US', state='CA', city='Palo Alto')
     [u'America/Los_Angeles']
@@ -169,7 +169,7 @@ def tz_ids_for_address(country, state=None, city=None, zipcode=None, **kwargs):
 
 
 def tz_ids_for_offset(offset_in_minutes):
-    """ Get the TZ identifiers for a given UTC offset (in minutes), e.g.
+    """Get the TZ identifiers for a given UTC offset (in minutes), e.g.
 
     >>> tztrout.tz_ids_for_offset(-7 * 60)  # during DST
     [
@@ -204,7 +204,7 @@ def tz_ids_for_offset(offset_in_minutes):
 
 
 def local_time_for_phone(phone, country='US'):
-    """ Get the local time for a given phone number, e.g.
+    """Get the local time for a given phone number, e.g.
 
     >>> datetime.datetime.utcnow()
     datetime.datetime(2013, 9, 17, 19, 44, 0, 966696)
@@ -219,7 +219,7 @@ def local_time_for_phone(phone, country='US'):
 def local_time_for_address(
     country, state=None, city=None, zipcode=None, **kwargs
 ):
-    """ Get the local time for a given address, e.g.
+    """Get the local time for a given address, e.g.
 
     >>> datetime.datetime.utcnow()
     datetime.datetime(2013, 9, 17, 19, 44, 0, 966696)
@@ -232,7 +232,7 @@ def local_time_for_address(
 
 
 def offset_ranges_for_local_time(local_start, local_end):
-    """ Return a list of UTC offset ranges where the local time is between
+    """Return a list of UTC offset ranges where the local time is between
     local_start and local_end, e.g.
 
     >>> tztrout.offset_ranges_for_local_time(datetime.time(9), datetime.time(17))  # ran at 8pm UTC
@@ -309,7 +309,7 @@ def offset_ranges_for_local_time(local_start, local_end):
 
 
 def tz_ids_for_offset_range(offset_start, offset_end):
-    """ Return all the time zone identifiers which offsets are within the
+    """Return all the time zone identifiers which offsets are within the
     (offset_start, offset_end) range. The arguments should be integers
     (UTC offsets in minutes).
 
@@ -341,7 +341,7 @@ def tz_ids_for_offset_range(offset_start, offset_end):
 
 
 def non_dst_offsets_for_phone(phone):
-    """ Return the non-DST offsets (in minutes) for a given phone, e.g.
+    """Return the non-DST offsets (in minutes) for a given phone, e.g.
 
     >>> tztrout.non_dst_offsets_for_phone('+1 650 248 6188')
     [-480]
@@ -359,7 +359,7 @@ def non_dst_offsets_for_phone(phone):
 def non_dst_offsets_for_address(
     country, state=None, city=None, zipcode=None, **kwargs
 ):
-    """ Return the non-DST offsets (in minutes) for a given address, e.g.
+    """Return the non-DST offsets (in minutes) for a given address, e.g.
 
     >>> tztrout.non_dst_offsets_for_address('US', state='CA')
     [-480]

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import operator
 import os
 from collections import defaultdict
 from sys import stdout
@@ -378,11 +377,11 @@ class TroutData(object):
 
 
 def _progressbar(lst):
-    l = len(lst)
+    list_length = len(lst)
     for cnt, elem in enumerate(lst):
         yield elem
         if cnt % 10 == 9:
-            stdout.write('\r%d/%d' % (cnt + 1, l))
+            stdout.write('\r%d/%d' % (cnt + 1, list_length))
             stdout.flush()
 
 

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -2,25 +2,39 @@ import datetime
 import json
 import operator
 import os
-import pytz
 from collections import defaultdict
 from sys import stdout
 
-from pyzipcode import ZipCodeDatabase, ZipCode
+import pytz
+from pyzipcode import ZipCode, ZipCodeDatabase
 
 from tztrout.data_exceptions import data_exceptions
 
 # paths to the data files
 basepath = os.path.dirname(os.path.abspath(__file__))
-US_ZIPS_TO_TZ_IDS_MAP_PATH = os.path.join(basepath, 'data/us_zips_to_tz_ids.json')
-TZ_NAME_TO_TZ_IDS_MAP_PATH = os.path.join(basepath, 'data/tz_name_to_tz_ids.json')
-OFFSET_TO_TZ_IDS_MAP_PATH = os.path.join(basepath, 'data/offset_to_tz_ids.json')
+US_ZIPS_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/us_zips_to_tz_ids.json'
+)
+TZ_NAME_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/tz_name_to_tz_ids.json'
+)
+OFFSET_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/offset_to_tz_ids.json'
+)
 STATES_PATH = os.path.join(basepath, 'data/normalized_states.json')
 ALIASES_PATH = os.path.join(basepath, 'data/tz_name_to_tz_name_aliases.json')
-CA_STATE_TO_TZ_IDS_MAP_PATH =  os.path.join(basepath, 'data/ca_state_to_tz_ids.json')
-CA_AREA_CODE_TO_STATE_MAP_PATH =  os.path.join(basepath, 'data/ca_area_code_to_state.json')
-AU_STATE_TO_TZ_IDS_MAP_PATH =  os.path.join(basepath, 'data/au_state_to_tz_ids.json')
-AU_AREA_CODE_TO_STATE_MAP_PATH =  os.path.join(basepath, 'data/au_area_code_to_state.json')
+CA_STATE_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/ca_state_to_tz_ids.json'
+)
+CA_AREA_CODE_TO_STATE_MAP_PATH = os.path.join(
+    basepath, 'data/ca_area_code_to_state.json'
+)
+AU_STATE_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/au_state_to_tz_ids.json'
+)
+AU_AREA_CODE_TO_STATE_MAP_PATH = os.path.join(
+    basepath, 'data/au_area_code_to_state.json'
+)
 
 # Australian TZ names are resolved as EST, WST, etc., which is ok for local
 # usage, but conflicts with the more common US TZ names if we're thinking
@@ -35,7 +49,7 @@ AU_MAP = {
     'CDT': 'ACDT',
     'EDT': 'AEDT',
     'CWDT': 'AWDT',
-    'LHDT': 'AEDT'
+    'LHDT': 'AEDT',
 }
 
 # Asia/Manila is resolved as PST (Philippine Standard Time), which is ok for
@@ -89,7 +103,10 @@ class InMemoryZipData(object):
         self.by_state_city = {}
         deduplicate = deduplicator()
 
-        for zip in map(ZipCode, ZipCodeDatabase().conn_manager.query("SELECT * FROM ZipCodes", [])):
+        for zip in map(
+            ZipCode,
+            ZipCodeDatabase().conn_manager.query("SELECT * FROM ZipCodes", []),
+        ):
             code = deduplicate(zip.zip)
             state = deduplicate(zip.state)
             city = deduplicate(zip.city)
@@ -125,26 +142,36 @@ class TroutData(object):
     # Sometimes we need to go back a few steps to figure out DSTs, timezone
     # names, etc. This is a kwargs dict that is passed to datetime.timedelta
     # to determine the size of a single step
-    TD_STEP = { 'days': 40 }
+    TD_STEP = {'days': 40}
 
     def __init__(self):
         # load the data files, if they exist
-        self._load_us_zipcode_data('us_zip_to_tz_ids', US_ZIPS_TO_TZ_IDS_MAP_PATH)
+        self._load_us_zipcode_data(
+            'us_zip_to_tz_ids', US_ZIPS_TO_TZ_IDS_MAP_PATH
+        )
         self._load_data('tz_name_to_tz_ids', TZ_NAME_TO_TZ_IDS_MAP_PATH)
         self._load_data('offset_to_tz_ids', OFFSET_TO_TZ_IDS_MAP_PATH)
         self._load_data('normalized_states', STATES_PATH)
         self._load_data('tz_name_aliases', ALIASES_PATH)
         self._load_data('ca_state_to_tz_ids', CA_STATE_TO_TZ_IDS_MAP_PATH)
-        self._load_data('ca_area_code_to_state', CA_AREA_CODE_TO_STATE_MAP_PATH)
+        self._load_data(
+            'ca_area_code_to_state', CA_AREA_CODE_TO_STATE_MAP_PATH
+        )
         self._load_data('au_state_to_tz_ids', AU_STATE_TO_TZ_IDS_MAP_PATH)
-        self._load_data('au_area_code_to_state', AU_AREA_CODE_TO_STATE_MAP_PATH)
+        self._load_data(
+            'au_area_code_to_state', AU_AREA_CODE_TO_STATE_MAP_PATH
+        )
 
         # convert string offsets into integers
-        self.offset_to_tz_ids = dict((int(k), v) for k, v in self.offset_to_tz_ids.items())
+        self.offset_to_tz_ids = dict(
+            (int(k), v) for k, v in self.offset_to_tz_ids.items()
+        )
 
         # flatten the values of all tz name aliases (needed to identify which
         # filters don't need to be exact in tztrout.tz_ids_for_tz_name
-        self.aliases = {alias for v in self.tz_name_aliases.values() for alias in v}
+        self.aliases = {
+            alias for v in self.tz_name_aliases.values() for alias in v
+        }
 
     def _load_data(self, name, path):
         """ Helper method to load a data file. """
@@ -156,7 +183,14 @@ class TroutData(object):
         dedupe = deduplicator()
         with open(path, 'r') as file:
             data = json.load(file)
-            setattr(self, name, {dedupe(k): dedupe(tuple(dedupe(tz) for tz in v)) for k, v in data.items()})
+            setattr(
+                self,
+                name,
+                {
+                    dedupe(k): dedupe(tuple(dedupe(tz) for tz in v))
+                    for k, v in data.items()
+                },
+            )
 
     def _get_latest_non_dst_offset(self, tz):
         """ Get the UTC offset for a given time zone identifier. Ignore the
@@ -245,7 +279,9 @@ class TroutData(object):
                 return
 
         # Find all the TZ identifiers with a non-DST offset of zipcode.timezone
-        tz_ids = self._get_tz_identifiers_for_offset('US', datetime.timedelta(hours=zipcode.timezone))
+        tz_ids = self._get_tz_identifiers_for_offset(
+            'US', datetime.timedelta(hours=zipcode.timezone)
+        )
 
         # For each of the found identifiers, cross-reference the DST data from
         # pytz and pyzipcode and only include the identifier if they match
@@ -269,15 +305,34 @@ class TroutData(object):
             ids = tuple(self._get_tz_identifiers_for_us_zipcode(zip))
 
             # apply the data exceptions
-            exceptions = data_exceptions.get('zip:' + zip.zip) or data_exceptions.get('state:' + zip.state) or {}
-            exceptions['include'] = exceptions.get('include', []) + data_exceptions['all'].get('include', []) if 'all' in data_exceptions else []
-            exceptions['exclude'] = exceptions.get('exclude', []) + data_exceptions['all'].get('exclude', []) if 'all' in data_exceptions else []
+            exceptions = (
+                data_exceptions.get('zip:' + zip.zip)
+                or data_exceptions.get('state:' + zip.state)
+                or {}
+            )
+            exceptions['include'] = (
+                exceptions.get('include', [])
+                + data_exceptions['all'].get('include', [])
+                if 'all' in data_exceptions
+                else []
+            )
+            exceptions['exclude'] = (
+                exceptions.get('exclude', [])
+                + data_exceptions['all'].get('exclude', [])
+                if 'all' in data_exceptions
+                else []
+            )
             if exceptions:
-                ids = tuple((set(ids) - set(exceptions['exclude'])) | set(exceptions['include']))
+                ids = tuple(
+                    (set(ids) - set(exceptions['exclude']))
+                    | set(exceptions['include'])
+                )
 
             tz_ids_to_zips[ids].append(zip.zip)
 
-        zips_to_tz_ids = {zip: ids for ids, zips in tz_ids_to_zips.items() for zip in zips}
+        zips_to_tz_ids = {
+            zip: ids for ids, zips in tz_ids_to_zips.items() for zip in zips
+        }
 
         _dump_json_data(US_ZIPS_TO_TZ_IDS_MAP_PATH, zips_to_tz_ids)
 
@@ -334,4 +389,3 @@ def _progressbar(lst):
 def _dump_json_data(path, data):
     with open(path, 'w') as f:
         json.dump(data, f, indent=2, sort_keys=True, separators=(',', ': '))
-

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -131,7 +131,7 @@ ZIP_DATA = InMemoryZipData()
 
 
 class TroutData(object):
-    """ Helper class that generates the JSON data used by TZTrout """
+    """Helper class that generates the JSON data used by TZTrout"""
 
     # We don't care about the historic data - we just want to know the recent
     # state of time zones, zip codes, etc. RECENT_YEARS_START describes how
@@ -173,7 +173,7 @@ class TroutData(object):
         }
 
     def _load_data(self, name, path):
-        """ Helper method to load a data file. """
+        """Helper method to load a data file."""
         with open(path, 'r') as file:
             data = json.loads(file.read())
             setattr(self, name, data)
@@ -192,7 +192,7 @@ class TroutData(object):
             )
 
     def _get_latest_non_dst_offset(self, tz):
-        """ Get the UTC offset for a given time zone identifier. Ignore the
+        """Get the UTC offset for a given time zone identifier. Ignore the
         DST offsets.
         """
         dt = datetime.datetime.utcnow()
@@ -206,7 +206,7 @@ class TroutData(object):
             dt -= datetime.timedelta(**self.TD_STEP)
 
     def _get_latest_offsets(self, tz):
-        """ Get all the UTC offsets (in minutes) that a given time zone
+        """Get all the UTC offsets (in minutes) that a given time zone
         experienced in the recent years.
         """
         dt = datetime.datetime.utcnow()
@@ -222,7 +222,7 @@ class TroutData(object):
         return offsets
 
     def _experiences_dst(self, tz):
-        """ Check if the time zone identifier has experienced the DST in the
+        """Check if the time zone identifier has experienced the DST in the
         recent years.
         """
         dt = datetime.datetime.utcnow()
@@ -237,7 +237,7 @@ class TroutData(object):
         return False
 
     def _get_latest_tz_names(self, tz):
-        """ Get the recent time zone names for a given time zone identifier.
+        """Get the recent time zone names for a given time zone identifier.
         """
         dt = datetime.datetime.utcnow()
         tz_names = []
@@ -255,7 +255,7 @@ class TroutData(object):
         return tz_names
 
     def _get_tz_identifiers_for_offset(self, country, offset):
-        """ Get all the possible time zone identifiers for a given UTC offset.
+        """Get all the possible time zone identifiers for a given UTC offset.
         Ignore the DST offsets.
         """
         identifiers = pytz.country_timezones.get(country)
@@ -268,7 +268,7 @@ class TroutData(object):
         return ids
 
     def _get_tz_identifiers_for_us_zipcode(self, zipcode):
-        """ Get all the possible identifiers for a given US zip code.
+        """Get all the possible identifiers for a given US zip code.
         """
         if not isinstance(zipcode, ZipCode):
             zipcode = ZipCodeDatabase().get(zipcode)
@@ -293,7 +293,7 @@ class TroutData(object):
         return ret_ids
 
     def generate_zip_to_tz_id_map(self):
-        """ Generate the map of US zip codes to time zone identifiers. The
+        """Generate the map of US zip codes to time zone identifiers. The
         method finds all the possible time zone identifiers for each zip code
         based on a UTC offset stored for that zip in pyzipcode.ZipCodeDatabase.
         """
@@ -336,7 +336,7 @@ class TroutData(object):
         _dump_json_data(US_ZIPS_TO_TZ_IDS_MAP_PATH, zips_to_tz_ids)
 
     def generate_tz_name_to_tz_id_map(self):
-        """ Generate the map of timezone names to time zone identifiers.
+        """Generate the map of timezone names to time zone identifiers.
         """
         tz_name_ids = {}
         for id in _progressbar(pytz.common_timezones):
@@ -364,7 +364,7 @@ class TroutData(object):
         _dump_json_data(TZ_NAME_TO_TZ_IDS_MAP_PATH, tz_name_ids)
 
     def generate_offset_to_tz_id_map(self):
-        """ Generate the map of UTC offsets to time zone identifiers.
+        """Generate the map of UTC offsets to time zone identifiers.
         """
         offset_tz_ids = defaultdict(list)
         for id in _progressbar(pytz.common_timezones):

--- a/tztrout/data_exceptions.py
+++ b/tztrout/data_exceptions.py
@@ -14,41 +14,33 @@ that's *the only* tz id to be returned for tztrout.tz_ids_for_address('US', stat
 """
 
 data_exceptions = {
-
     'all': {
-        'exclude': ['America/Indiana/Tell_City', 'America/Indiana/Knox',
-                    'America/North_Dakota/Beulah', 'America/Indiana/Winamac',
-                    'America/Indiana/Petersburg', 'America/Indiana/Vincennes']
+        'exclude': [
+            'America/Indiana/Tell_City',
+            'America/Indiana/Knox',
+            'America/North_Dakota/Beulah',
+            'America/Indiana/Winamac',
+            'America/Indiana/Petersburg',
+            'America/Indiana/Vincennes',
+        ]
     },
-
     'state:NY': {
-        'exclude': [u'America/Indiana/Winamac', u'America/Indiana/Petersburg',
-                    u'America/Indiana/Vincennes']
+        'exclude': [
+            u'America/Indiana/Winamac',
+            u'America/Indiana/Petersburg',
+            u'America/Indiana/Vincennes',
+        ]
     },
-
     'state:PA': {
-        'exclude': [u'America/Indiana/Winamac', u'America/Indiana/Petersburg',
-                    u'America/Indiana/Vincennes']
+        'exclude': [
+            u'America/Indiana/Winamac',
+            u'America/Indiana/Petersburg',
+            u'America/Indiana/Vincennes',
+        ]
     },
-
-    'state:IN': {
-        'include': ['America/Indiana/Indianapolis']
-    },
-
-    'city:el paso': {
-        'include': ['America/Denver']
-    },
-
-    'areacode:915': {
-        'include': ['America/Denver']
-    },
-
-    'areacode:901': {
-        'include': ['America/Chicago']
-    },
-
-    'areacode:202': {
-        'include': ['America/New_York']
-    }
-
+    'state:IN': {'include': ['America/Indiana/Indianapolis']},
+    'city:el paso': {'include': ['America/Denver']},
+    'areacode:915': {'include': ['America/Denver']},
+    'areacode:901': {'include': ['America/Chicago']},
+    'areacode:202': {'include': ['America/New_York']},
 }


### PR DESCRIPTION
This commit adds `black`, `flake8`, and `isort` to the build steps for `tz-trout` and reconfigures `config.yaml` to look more like those of limitlion and tasktiger. 

The `flake8` and `isort` configs were adapted from limitlion and the `black` `pyproject.toml` was adapted from tasktiger.

In order to run the proper pinned version of black, we had to switch .circleCI from python 3.5 to python 3.6 as well. 