### PR TITLE
Add black, flake8, and isort to tz-trout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ workflows:
   workflow:
     jobs:
       - test-3.5
+      - test-3.6
 
 defaults: &defaults
   working_directory: ~/code
@@ -22,3 +23,8 @@ jobs:
     <<: *defaults
     docker:
     - image: circleci/python:3.5
+  
+  test-3.6:
+      <<: *defaults
+      docker:
+      - image: circleci/python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,10 +28,13 @@ jobs:
     - checkout
     - run:
         name: Prepare Environment
-        command: pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming
+        command: pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming isort
     - run:
         name: Flake8
         command: flake8
+    - run:
+        name: Isort
+        command: isort -rc -c .
     
   test-3.5:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ workflows:
   version: 2
   workflow:
     jobs:
+      - static-code-analysis
       - test-3.5
       - test-3.6
 
@@ -19,6 +20,19 @@ defaults: &defaults
       command: pytest
 
 jobs:
+  static-code-analysis:
+    docker:
+    - image: circleci/python:3.6
+    working_directory: ~/code
+    steps:
+    - checkout
+    - run:
+        name: Prepare Environment
+        command: pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming
+    - run:
+        name: Flake8
+        command: flake8
+    
   test-3.5:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,10 @@ jobs:
     - checkout
     - run:
         name: Prepare Environment
-        command: pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming isort
+        command: pip install flake8 flake8-docstrings flake8-polyfill pep8 pep8-naming isort black==19.10b0
+    - run:
+        name: Black
+        command: black --check .
     - run:
         name: Flake8
         command: flake8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+[tool.black]
+skip-string-normalization = true
+line-length = 79
+exclude = '''
+/(
+    \.git
+  | \.venv
+)/
+'''

--- a/regenerate_data.py
+++ b/regenerate_data.py
@@ -3,6 +3,7 @@
 Run this script when you upgrade dependencies.
 Commit changes after the run.
 """
+
 import sys
 
 sys.path.append('.')

--- a/regenerate_data.py
+++ b/regenerate_data.py
@@ -6,9 +6,10 @@ Commit changes after the run.
 
 import sys
 
+from tztrout import td
+
 sys.path.append('.')
 
-from tztrout import td
 
 if __name__ == '__main__':
     td.generate_tz_name_to_tz_id_map()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [tool:pytest]
 testpaths=tests
+
+[flake8]
+application-import-names=tztrout
+exclude=build,dist,docs,venv,.eggs,config
+ignore=D100,D101,D102,D104,D205,D107,D400,D401,E2,E124,E127,E128,E402,E501,E731,W503,W504
+import-order-style=google
+max-complexity=14

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,13 @@ exclude=build,dist,docs,venv,.eggs,config
 ignore=D100,D101,D102,D104,D205,D107,D400,D401,E2,E124,E127,E128,E402,E501,E731,W503,W504
 import-order-style=google
 max-complexity=14
+
+[isort]
+skip=.tox,venv
+not_skip=__init__.py
+known_first_party=tztrout
+known_tests=tests
+sections=FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER
+default_section=THIRDPARTY
+use_parentheses=true
+multi_line_output=5

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,8 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ],
-    packages=[
-        'tztrout',
-    ],
-    package_data={
-        'tztrout': ['data/*']
-    },
+    packages=['tztrout',],
+    package_data={'tztrout': ['data/*']},
     install_requires=[
         'phonenumbers>=8.3.0',
         'python-dateutil',

--- a/tests/test_tztrout.py
+++ b/tests/test_tztrout.py
@@ -19,7 +19,6 @@ def assert_only_one_tz(ids, expected_tz_name, tz_names):
     would fail because 'America/New_York' is in the ET timezone and 'America/Los_Angeles' is
     in the 'PT' timezone.
     """
-
     assert expected_tz_name in tz_names
     expected_tz_ids = set(tztrout.tz_ids_for_tz_name(expected_tz_name))
 
@@ -40,7 +39,7 @@ def assert_only_one_tz(ids, expected_tz_name, tz_names):
 
 
 class FakeDateTime(datetime.datetime):
-    "A datetime replacement that lets you set utcnow()"
+    """A datetime replacement that lets you set utcnow()"""
 
     @classmethod
     def utcnow(cls, *args, **kwargs):
@@ -148,8 +147,9 @@ class TestTZIdsForPhone:
     def test_major_cities_us_ca(
         self, phone, tz_name,
     ):
-        """ Make sure all the major cities in the United States and Canada match the right time zone
-        (and the right time zone only). """
+        """Make sure all the major cities in the United States and Canada match the right time zone
+        (and the right time zone only).
+        """
         ids = tztrout.tz_ids_for_phone(phone)
         assert_only_one_tz(ids, tz_name, US_CA_TZ_NAMES)
 
@@ -212,8 +212,9 @@ class TestTZIdsForPhone:
         ],
     )
     def test_major_cities_australia(self, phone, tz_name):
-        """ Make sure all the major cities in Australia match the right time zone
-        (and the right time zone only)."""
+        """Make sure all the major cities in Australia match the right time zone
+        (and the right time zone only).
+        """
         ids = tztrout.tz_ids_for_phone(phone)
         assert_only_one_tz(ids, tz_name, AU_TZ_NAMES)
 
@@ -352,8 +353,9 @@ class TestTZIdsForAddress:
     def test_major_cities_us_ca(
         self, country, state, city, tz_name,
     ):
-        """ Make sure all the major cities in the United States and Canada match the right time zone
-        (and the right time zone only)."""
+        """Make sure all the major cities in the United States and Canada match the right time zone
+        (and the right time zone only).
+        """
         ids = tztrout.tz_ids_for_address(country, state=state, city=city)
         assert_only_one_tz(ids, tz_name, US_CA_TZ_NAMES)
 
@@ -380,8 +382,9 @@ class TestTZIdsForAddress:
         ],
     )
     def test_major_cities_australia(self, state, city, tz_name):
-        """ Make sure all the major cities in Australia match the right time zone
-        (and the right time zone only). """
+        """Make sure all the major cities in Australia match the right time zone
+        (and the right time zone only).
+        """
         ids = tztrout.tz_ids_for_address('AU', state=state, city=city)
         assert_only_one_tz(ids, tz_name, AU_TZ_NAMES)
 

--- a/tests/test_tztrout.py
+++ b/tests/test_tztrout.py
@@ -502,7 +502,11 @@ class TestOffsetRangesForLocalTime:
         ],
     )
     def test_offset_ranges(
-        self, hour_now, local_time_start, local_time_end, expected_offset_results
+        self,
+        hour_now,
+        local_time_start,
+        local_time_end,
+        expected_offset_results,
     ):
         FakeDateTime.set_utcnow(datetime.datetime(2013, 1, 1, hour_now))
         offset_ranges = tztrout.offset_ranges_for_local_time(

--- a/tests/test_tztrout.py
+++ b/tests/test_tztrout.py
@@ -1,8 +1,9 @@
 import datetime
 
 import pytest
-import tztrout
 from mock import patch
+
+import tztrout
 
 US_CA_TZ_NAMES = ['PT', 'MT', 'CT', 'ET', 'AT']
 AU_TZ_NAMES = ['AWT', 'ACT', 'AET']

--- a/tztrout/__init__.py
+++ b/tztrout/__init__.py
@@ -1,14 +1,13 @@
 import datetime
 import operator
-import phonenumbers
-import pytz
-
-from dateutil.parser import parse as parse_date
 from functools import reduce
 
-from tztrout.data import TroutData, ZIP_DATA
-from tztrout.data_exceptions import data_exceptions
+import phonenumbers
+import pytz
+from dateutil.parser import parse as parse_date
 
+from tztrout.data import ZIP_DATA, TroutData
+from tztrout.data_exceptions import data_exceptions
 
 td = TroutData()
 

--- a/tztrout/__init__.py
+++ b/tztrout/__init__.py
@@ -71,7 +71,9 @@ def tz_ids_for_phone(phone, country='US'):
     else:
         country_iso = phonenumbers.region_code_for_number(phone)
         if not country_iso:
-            country_iso = phonenumbers.region_code_for_country_code(phone.country_code)
+            country_iso = phonenumbers.region_code_for_country_code(
+                phone.country_code
+            )
 
         if country_iso == 'US':
 
@@ -211,7 +213,9 @@ def local_time_for_phone(phone, country='US'):
         return pytz.timezone(ids[0]).fromutc(datetime.datetime.utcnow())
 
 
-def local_time_for_address(country, state=None, city=None, zipcode=None, **kwargs):
+def local_time_for_address(
+    country, state=None, city=None, zipcode=None, **kwargs
+):
     """Get the local time for a given address, e.g.
 
     >>> datetime.datetime.utcnow()
@@ -248,18 +252,36 @@ def offset_ranges_for_local_time(local_start, local_end):
     [[-660, -180], [780, 840]]
     """
     if not isinstance(local_start, (datetime.time, int, str)):
-        raise ValueError('local_start is not an instance of datetime.time or int or str')
+        raise ValueError(
+            'local_start is not an instance of datetime.time or int or str'
+        )
     if not isinstance(local_end, (datetime.time, int, str)):
-        raise ValueError('local_end is not an instance of datetime.time or int or str')
+        raise ValueError(
+            'local_end is not an instance of datetime.time or int or str'
+        )
 
     # Convert to `datetime.time` if `local_start` or `local_end` are strings.
-    local_start = parse_date(local_start).time() if isinstance(local_start, str) else local_start
-    local_end = parse_date(local_end).time() if isinstance(local_end, str) else local_end
+    local_start = (
+        parse_date(local_start).time()
+        if isinstance(local_start, str)
+        else local_start
+    )
+    local_end = (
+        parse_date(local_end).time()
+        if isinstance(local_end, str)
+        else local_end
+    )
 
     # Convert to ints (minutes).
     to_minutes = lambda t: t.hour * 60 + t.minute
-    local_start = local_start if isinstance(local_start, int) else to_minutes(local_start)
-    local_end = local_end if isinstance(local_end, int) else to_minutes(local_end)
+    local_start = (
+        local_start
+        if isinstance(local_start, int)
+        else to_minutes(local_start)
+    )
+    local_end = (
+        local_end if isinstance(local_end, int) else to_minutes(local_end)
+    )
 
     # Get current UTC time.
     current_time = to_minutes(datetime.datetime.utcnow().time())
@@ -271,13 +293,21 @@ def offset_ranges_for_local_time(local_start, local_end):
     # Calculate UTC offsets.
     offset_ranges = [
         [local_start - current_time, local_end - current_time],
-        [24 * 60 - current_time + local_start, 24 * 60 - current_time + local_end],
-        [-24 * 60 - current_time + local_start, -24 * 60 - current_time + local_end]
+        [
+            24 * 60 - current_time + local_start,
+            24 * 60 - current_time + local_end,
+        ],
+        [
+            -24 * 60 - current_time + local_start,
+            -24 * 60 - current_time + local_end,
+        ],
     ]
 
     # Cap the offsets at UTC-14:00 and UTC+14:00 (lowest/highest possible
     # offset).
-    capped = lambda t: 14 * 60 if t > 14 * 60 else -14 * 60 if t < -14 * 60 else t
+    capped = (
+        lambda t: 14 * 60 if t > 14 * 60 else -14 * 60 if t < -14 * 60 else t
+    )
     for i, range in enumerate(offset_ranges):
         offset_ranges[i][0] = capped(range[0])
         offset_ranges[i][1] = capped(range[1])
@@ -308,8 +338,11 @@ def tz_ids_for_offset_range(offset_start, offset_end):
         u'US/Arizona', u'US/Pacific'
     ]
     """
-    offsets = [int(o) for o in td.offset_to_tz_ids.keys() if (
-        int(o) >= offset_start and int(o) <= offset_end)]
+    offsets = [
+        int(o)
+        for o in td.offset_to_tz_ids.keys()
+        if (int(o) >= offset_start and int(o) <= offset_end)
+    ]
     ids = [tz_ids_for_offset(o) for o in offsets]
     if ids:
         ids = reduce(operator.add, ids)  # flatten the list of lists
@@ -324,17 +357,29 @@ def non_dst_offsets_for_phone(phone):
     """
     ids = tz_ids_for_phone(phone)
     if ids:
-        offsets = [td._get_latest_non_dst_offset(pytz.timezone(id)) for id in ids]
-        return _dedupe_preserve_ord([int(o.total_seconds() / 60) for o in offsets if o])
+        offsets = [
+            td._get_latest_non_dst_offset(pytz.timezone(id)) for id in ids
+        ]
+        return _dedupe_preserve_ord(
+            [int(o.total_seconds() / 60) for o in offsets if o]
+        )
 
 
-def non_dst_offsets_for_address(country, state=None, city=None, zipcode=None, **kwargs):
+def non_dst_offsets_for_address(
+    country, state=None, city=None, zipcode=None, **kwargs
+):
     """Return the non-DST offsets (in minutes) for a given address, e.g.
 
     >>> tztrout.non_dst_offsets_for_address('US', state='CA')
     [-480]
     """
-    ids = tz_ids_for_address(country, state=state, city=city, zipcode=zipcode, **kwargs)
+    ids = tz_ids_for_address(
+        country, state=state, city=city, zipcode=zipcode, **kwargs
+    )
     if ids:
-        offsets = [td._get_latest_non_dst_offset(pytz.timezone(id)) for id in ids]
-        return _dedupe_preserve_ord([int(o.total_seconds() / 60) for o in offsets if o])
+        offsets = [
+            td._get_latest_non_dst_offset(pytz.timezone(id)) for id in ids
+        ]
+        return _dedupe_preserve_ord(
+            [int(o.total_seconds() / 60) for o in offsets if o]
+        )

--- a/tztrout/__init__.py
+++ b/tztrout/__init__.py
@@ -12,13 +12,15 @@ from tztrout.data_exceptions import data_exceptions
 
 td = TroutData()
 
+
 def _dedupe_preserve_ord(lst):
-    """ Dedupe a list and preserve the order of its items. """
+    """Dedupe a list and preserve the order of its items."""
     seen = set()
     return [x for x in lst if x not in seen and not seen.add(x)]
 
+
 def tz_ids_for_tz_name(tz_name):
-    """ Get the TZ identifiers that are currently in a specific time zone, e.g.
+    """Get the TZ identifiers that are currently in a specific time zone, e.g.
 
     >>> tztrout.tz_ids_for_tz_name('PDT')  # ran during DST
     [
@@ -34,7 +36,6 @@ def tz_ids_for_tz_name(tz_name):
     >>> tztrout.tz_ids_for_tz_name('PDT')  # ran outside of the DST period
     []
     """
-
     ids = td.tz_name_to_tz_ids.get(tz_name)
 
     # if the tz_name is just an alias, don't perform the fine-grained filtering
@@ -55,19 +56,18 @@ def tz_ids_for_tz_name(tz_name):
 
 
 def tz_ids_for_phone(phone, country='US'):
-    """ Get the TZ identifiers that a phone number might be related to, e.g.
+    """Get the TZ identifiers that a phone number might be related to, e.g.
 
     >>> tztrout.tz_ids_for_phone('+16503334444')
     [u'America/Los_Angeles']
     >>> tztrout.tz_ids_for_phone('+49 (0)711 400 40990')
     [u'Europe/Berlin', u'Europe/Busingen']
     """
-
     from phonenumbers.geocoder import description_for_number
 
     try:
         phone = phonenumbers.parse(phone, country)
-    except:
+    except Exception:
         pass
     else:
         country_iso = phonenumbers.region_code_for_number(phone)
@@ -114,7 +114,7 @@ def tz_ids_for_phone(phone, country='US'):
 
 
 def tz_ids_for_address(country, state=None, city=None, zipcode=None, **kwargs):
-    """ Get the TZ identifiers for a given address, e.g.:
+    """Get the TZ identifiers for a given address, e.g.:
 
     >>> tztrout.tz_ids_for_address('US', state='CA', city='Palo Alto')
     [u'America/Los_Angeles']
@@ -129,7 +129,6 @@ def tz_ids_for_address(country, state=None, city=None, zipcode=None, **kwargs):
         u'Asia/Kashgar'
     ]
     """
-
     if country == 'US':
         if zipcode:
             if isinstance(zipcode, int):
@@ -164,8 +163,9 @@ def tz_ids_for_address(country, state=None, city=None, zipcode=None, **kwargs):
 
     return pytz.country_timezones.get(country)
 
+
 def tz_ids_for_offset(offset_in_minutes):
-    """ Get the TZ identifiers for a given UTC offset (in minutes), e.g.
+    """Get the TZ identifiers for a given UTC offset (in minutes), e.g.
 
     >>> tztrout.tz_ids_for_offset(-7 * 60)  # during DST
     [
@@ -198,8 +198,9 @@ def tz_ids_for_offset(offset_in_minutes):
                 pass
     return valid_ids
 
+
 def local_time_for_phone(phone, country='US'):
-    """ Get the local time for a given phone number, e.g.
+    """Get the local time for a given phone number, e.g.
 
     >>> datetime.datetime.utcnow()
     datetime.datetime(2013, 9, 17, 19, 44, 0, 966696)
@@ -210,8 +211,9 @@ def local_time_for_phone(phone, country='US'):
     if ids:
         return pytz.timezone(ids[0]).fromutc(datetime.datetime.utcnow())
 
+
 def local_time_for_address(country, state=None, city=None, zipcode=None, **kwargs):
-    """ Get the local time for a given address, e.g.
+    """Get the local time for a given address, e.g.
 
     >>> datetime.datetime.utcnow()
     datetime.datetime(2013, 9, 17, 19, 44, 0, 966696)
@@ -221,6 +223,7 @@ def local_time_for_address(country, state=None, city=None, zipcode=None, **kwarg
     ids = tz_ids_for_address(country, state, city, zipcode, **kwargs)
     if ids:
         return pytz.timezone(ids[0]).fromutc(datetime.datetime.utcnow())
+
 
 def offset_ranges_for_local_time(local_start, local_end):
     """Return a list of UTC offset ranges matching a given local time range.
@@ -284,8 +287,9 @@ def offset_ranges_for_local_time(local_start, local_end):
     offset_ranges = [range for range in offset_ranges if range[0] != range[1]]
     return offset_ranges
 
+
 def tz_ids_for_offset_range(offset_start, offset_end):
-    """ Return all the time zone identifiers which offsets are within the
+    """Return all the time zone identifiers which offsets are within the
     (offset_start, offset_end) range. The arguments should be integers
     (UTC offsets in minutes).
 
@@ -306,14 +310,15 @@ def tz_ids_for_offset_range(offset_start, offset_end):
     ]
     """
     offsets = [int(o) for o in td.offset_to_tz_ids.keys() if (
-                            int(o) >= offset_start and int(o) <= offset_end)]
+        int(o) >= offset_start and int(o) <= offset_end)]
     ids = [tz_ids_for_offset(o) for o in offsets]
     if ids:
         ids = reduce(operator.add, ids)  # flatten the list of lists
     return ids
 
+
 def non_dst_offsets_for_phone(phone):
-    """ Return the non-DST offsets (in minutes) for a given phone, e.g.
+    """Return the non-DST offsets (in minutes) for a given phone, e.g.
 
     >>> tztrout.non_dst_offsets_for_phone('+1 650 248 6188')
     [-480]
@@ -323,8 +328,9 @@ def non_dst_offsets_for_phone(phone):
         offsets = [td._get_latest_non_dst_offset(pytz.timezone(id)) for id in ids]
         return _dedupe_preserve_ord([int(o.total_seconds() / 60) for o in offsets if o])
 
+
 def non_dst_offsets_for_address(country, state=None, city=None, zipcode=None, **kwargs):
-    """ Return the non-DST offsets (in minutes) for a given address, e.g.
+    """Return the non-DST offsets (in minutes) for a given address, e.g.
 
     >>> tztrout.non_dst_offsets_for_address('US', state='CA')
     [-480]
@@ -333,4 +339,3 @@ def non_dst_offsets_for_address(country, state=None, city=None, zipcode=None, **
     if ids:
         offsets = [td._get_latest_non_dst_offset(pytz.timezone(id)) for id in ids]
         return _dedupe_preserve_ord([int(o.total_seconds() / 60) for o in offsets if o])
-

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -11,15 +11,29 @@ from tztrout.data_exceptions import data_exceptions
 
 # paths to the data files
 basepath = os.path.dirname(os.path.abspath(__file__))
-US_ZIPS_TO_TZ_IDS_MAP_PATH = os.path.join(basepath, 'data/us_zips_to_tz_ids.json')
-TZ_NAME_TO_TZ_IDS_MAP_PATH = os.path.join(basepath, 'data/tz_name_to_tz_ids.json')
-OFFSET_TO_TZ_IDS_MAP_PATH = os.path.join(basepath, 'data/offset_to_tz_ids.json')
+US_ZIPS_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/us_zips_to_tz_ids.json'
+)
+TZ_NAME_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/tz_name_to_tz_ids.json'
+)
+OFFSET_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/offset_to_tz_ids.json'
+)
 STATES_PATH = os.path.join(basepath, 'data/normalized_states.json')
 ALIASES_PATH = os.path.join(basepath, 'data/tz_name_to_tz_name_aliases.json')
-CA_STATE_TO_TZ_IDS_MAP_PATH =  os.path.join(basepath, 'data/ca_state_to_tz_ids.json')
-CA_AREA_CODE_TO_STATE_MAP_PATH =  os.path.join(basepath, 'data/ca_area_code_to_state.json')
-AU_STATE_TO_TZ_IDS_MAP_PATH =  os.path.join(basepath, 'data/au_state_to_tz_ids.json')
-AU_AREA_CODE_TO_STATE_MAP_PATH =  os.path.join(basepath, 'data/au_area_code_to_state.json')
+CA_STATE_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/ca_state_to_tz_ids.json'
+)
+CA_AREA_CODE_TO_STATE_MAP_PATH = os.path.join(
+    basepath, 'data/ca_area_code_to_state.json'
+)
+AU_STATE_TO_TZ_IDS_MAP_PATH = os.path.join(
+    basepath, 'data/au_state_to_tz_ids.json'
+)
+AU_AREA_CODE_TO_STATE_MAP_PATH = os.path.join(
+    basepath, 'data/au_area_code_to_state.json'
+)
 
 # Australian TZ names are resolved as EST, WST, etc., which is ok for local
 # usage, but conflicts with the more common US TZ names if we're thinking
@@ -34,7 +48,7 @@ AU_MAP = {
     'CDT': 'ACDT',
     'EDT': 'AEDT',
     'CWDT': 'AWDT',
-    'LHDT': 'AEDT'
+    'LHDT': 'AEDT',
 }
 
 # Asia/Manila is resolved as PST (Philippine Standard Time), which is ok for
@@ -88,7 +102,10 @@ class InMemoryZipData(object):
         self.by_state_city = {}
         deduplicate = deduplicator()
 
-        for zip in map(ZipCode, ZipCodeDatabase().conn_manager.query("SELECT * FROM ZipCodes", [])):
+        for zip in map(
+            ZipCode,
+            ZipCodeDatabase().conn_manager.query("SELECT * FROM ZipCodes", []),
+        ):
             code = deduplicate(zip.zip)
             state = deduplicate(zip.state)
             city = deduplicate(zip.city)
@@ -124,26 +141,36 @@ class TroutData(object):
     # Sometimes we need to go back a few steps to figure out DSTs, timezone
     # names, etc. This is a kwargs dict that is passed to datetime.timedelta
     # to determine the size of a single step
-    TD_STEP = { 'days': 40 }
+    TD_STEP = {'days': 40}
 
     def __init__(self):
         # load the data files, if they exist
-        self._load_us_zipcode_data('us_zip_to_tz_ids', US_ZIPS_TO_TZ_IDS_MAP_PATH)
+        self._load_us_zipcode_data(
+            'us_zip_to_tz_ids', US_ZIPS_TO_TZ_IDS_MAP_PATH
+        )
         self._load_data('tz_name_to_tz_ids', TZ_NAME_TO_TZ_IDS_MAP_PATH)
         self._load_data('offset_to_tz_ids', OFFSET_TO_TZ_IDS_MAP_PATH)
         self._load_data('normalized_states', STATES_PATH)
         self._load_data('tz_name_aliases', ALIASES_PATH)
         self._load_data('ca_state_to_tz_ids', CA_STATE_TO_TZ_IDS_MAP_PATH)
-        self._load_data('ca_area_code_to_state', CA_AREA_CODE_TO_STATE_MAP_PATH)
+        self._load_data(
+            'ca_area_code_to_state', CA_AREA_CODE_TO_STATE_MAP_PATH
+        )
         self._load_data('au_state_to_tz_ids', AU_STATE_TO_TZ_IDS_MAP_PATH)
-        self._load_data('au_area_code_to_state', AU_AREA_CODE_TO_STATE_MAP_PATH)
+        self._load_data(
+            'au_area_code_to_state', AU_AREA_CODE_TO_STATE_MAP_PATH
+        )
 
         # convert string offsets into integers
-        self.offset_to_tz_ids = dict((int(k), v) for k, v in self.offset_to_tz_ids.items())
+        self.offset_to_tz_ids = dict(
+            (int(k), v) for k, v in self.offset_to_tz_ids.items()
+        )
 
         # flatten the values of all tz name aliases (needed to identify which
         # filters don't need to be exact in tztrout.tz_ids_for_tz_name
-        self.aliases = {alias for v in self.tz_name_aliases.values() for alias in v}
+        self.aliases = {
+            alias for v in self.tz_name_aliases.values() for alias in v
+        }
 
     def _load_data(self, name, path):
         """Helper method to load a data file"""
@@ -155,7 +182,14 @@ class TroutData(object):
         dedupe = deduplicator()
         with open(path, 'r') as file:
             data = json.load(file)
-            setattr(self, name, {dedupe(k): dedupe(tuple(dedupe(tz) for tz in v)) for k, v in data.items()})
+            setattr(
+                self,
+                name,
+                {
+                    dedupe(k): dedupe(tuple(dedupe(tz) for tz in v))
+                    for k, v in data.items()
+                },
+            )
 
     def _get_latest_non_dst_offset(self, tz):
         """Get the UTC offset for a given time zone identifier. Ignore the
@@ -242,7 +276,9 @@ class TroutData(object):
                 return
 
         # Find all the TZ identifiers with a non-DST offset of zipcode.timezone
-        tz_ids = self._get_tz_identifiers_for_offset('US', datetime.timedelta(hours=zipcode.timezone))
+        tz_ids = self._get_tz_identifiers_for_offset(
+            'US', datetime.timedelta(hours=zipcode.timezone)
+        )
 
         # For each of the found identifiers, cross-reference the DST data from
         # pytz and pyzipcode and only include the identifier if they match
@@ -266,15 +302,34 @@ class TroutData(object):
             ids = tuple(self._get_tz_identifiers_for_us_zipcode(zip))
 
             # apply the data exceptions
-            exceptions = data_exceptions.get('zip:' + zip.zip) or data_exceptions.get('state:' + zip.state) or {}
-            exceptions['include'] = exceptions.get('include', []) + data_exceptions['all'].get('include', []) if 'all' in data_exceptions else []
-            exceptions['exclude'] = exceptions.get('exclude', []) + data_exceptions['all'].get('exclude', []) if 'all' in data_exceptions else []
+            exceptions = (
+                data_exceptions.get('zip:' + zip.zip)
+                or data_exceptions.get('state:' + zip.state)
+                or {}
+            )
+            exceptions['include'] = (
+                exceptions.get('include', [])
+                + data_exceptions['all'].get('include', [])
+                if 'all' in data_exceptions
+                else []
+            )
+            exceptions['exclude'] = (
+                exceptions.get('exclude', [])
+                + data_exceptions['all'].get('exclude', [])
+                if 'all' in data_exceptions
+                else []
+            )
             if exceptions:
-                ids = tuple((set(ids) - set(exceptions['exclude'])) | set(exceptions['include']))
+                ids = tuple(
+                    (set(ids) - set(exceptions['exclude']))
+                    | set(exceptions['include'])
+                )
 
             tz_ids_to_zips[ids].append(zip.zip)
 
-        zips_to_tz_ids = {zip: ids for ids, zips in tz_ids_to_zips.items() for zip in zips}
+        zips_to_tz_ids = {
+            zip: ids for ids, zips in tz_ids_to_zips.items() for zip in zips
+        }
 
         _dump_json_data(US_ZIPS_TO_TZ_IDS_MAP_PATH, zips_to_tz_ids)
 

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -1,11 +1,11 @@
 import datetime
 import json
 import os
-import pytz
 from collections import defaultdict
 from sys import stdout
 
-from pyzipcode import ZipCodeDatabase, ZipCode
+import pytz
+from pyzipcode import ZipCode, ZipCodeDatabase
 
 from tztrout.data_exceptions import data_exceptions
 

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import operator
 import os
 import pytz
 from collections import defaultdict
@@ -115,7 +114,7 @@ ZIP_DATA = InMemoryZipData()
 
 
 class TroutData(object):
-    """ Helper class that generates the JSON data used by TZTrout """
+    """Helper class that generates the JSON data used by TZTrout"""
 
     # We don't care about the historic data - we just want to know the recent
     # state of time zones, zip codes, etc. RECENT_YEARS_START describes how
@@ -147,7 +146,7 @@ class TroutData(object):
         self.aliases = {alias for v in self.tz_name_aliases.values() for alias in v}
 
     def _load_data(self, name, path):
-        """ Helper method to load a data file. """
+        """Helper method to load a data file"""
         with open(path, 'r') as file:
             data = json.loads(file.read())
             setattr(self, name, data)
@@ -159,7 +158,7 @@ class TroutData(object):
             setattr(self, name, {dedupe(k): dedupe(tuple(dedupe(tz) for tz in v)) for k, v in data.items()})
 
     def _get_latest_non_dst_offset(self, tz):
-        """ Get the UTC offset for a given time zone identifier. Ignore the
+        """Get the UTC offset for a given time zone identifier. Ignore the
         DST offsets.
         """
         dt = datetime.datetime.utcnow()
@@ -173,7 +172,7 @@ class TroutData(object):
             dt -= datetime.timedelta(**self.TD_STEP)
 
     def _get_latest_offsets(self, tz):
-        """ Get all the UTC offsets (in minutes) that a given time zone
+        """Get all the UTC offsets (in minutes) that a given time zone
         experienced in the recent years.
         """
         dt = datetime.datetime.utcnow()
@@ -189,7 +188,7 @@ class TroutData(object):
         return offsets
 
     def _experiences_dst(self, tz):
-        """ Check if the time zone identifier has experienced the DST in the
+        """Check if the time zone identifier has experienced the DST in the
         recent years.
         """
         dt = datetime.datetime.utcnow()
@@ -204,8 +203,7 @@ class TroutData(object):
         return False
 
     def _get_latest_tz_names(self, tz):
-        """ Get the recent time zone names for a given time zone identifier.
-        """
+        """Get the recent time zone names for a given time zone identifier."""
         dt = datetime.datetime.utcnow()
         tz_names = []
         while dt.year > self.RECENT_YEARS_START:
@@ -222,7 +220,7 @@ class TroutData(object):
         return tz_names
 
     def _get_tz_identifiers_for_offset(self, country, offset):
-        """ Get all the possible time zone identifiers for a given UTC offset.
+        """Get all the possible time zone identifiers for a given UTC offset.
         Ignore the DST offsets.
         """
         identifiers = pytz.country_timezones.get(country)
@@ -235,8 +233,7 @@ class TroutData(object):
         return ids
 
     def _get_tz_identifiers_for_us_zipcode(self, zipcode):
-        """ Get all the possible identifiers for a given US zip code.
-        """
+        """Get all the possible identifiers for a given US zip code."""
         if not isinstance(zipcode, ZipCode):
             zipcode = ZipCodeDatabase().get(zipcode)
             if zipcode:
@@ -258,7 +255,7 @@ class TroutData(object):
         return ret_ids
 
     def generate_zip_to_tz_id_map(self):
-        """ Generate the map of US zip codes to time zone identifiers. The
+        """Generate the map of US zip codes to time zone identifiers. The
         method finds all the possible time zone identifiers for each zip code
         based on a UTC offset stored for that zip in pyzipcode.ZipCodeDatabase.
         """
@@ -282,8 +279,7 @@ class TroutData(object):
         _dump_json_data(US_ZIPS_TO_TZ_IDS_MAP_PATH, zips_to_tz_ids)
 
     def generate_tz_name_to_tz_id_map(self):
-        """ Generate the map of timezone names to time zone identifiers.
-        """
+        """Generate the map of timezone names to time zone identifiers."""
         tz_name_ids = {}
         for id in _progressbar(pytz.common_timezones):
             tz = pytz.timezone(id)
@@ -310,8 +306,7 @@ class TroutData(object):
         _dump_json_data(TZ_NAME_TO_TZ_IDS_MAP_PATH, tz_name_ids)
 
     def generate_offset_to_tz_id_map(self):
-        """ Generate the map of UTC offsets to time zone identifiers.
-        """
+        """Generate the map of UTC offsets to time zone identifiers."""
         offset_tz_ids = defaultdict(list)
         for id in _progressbar(pytz.common_timezones):
             tz = pytz.timezone(id)
@@ -323,15 +318,14 @@ class TroutData(object):
 
 
 def _progressbar(lst):
-    l = len(lst)
+    length_of_list = len(lst)
     for cnt, elem in enumerate(lst):
         yield elem
         if cnt % 10 == 9:
-            stdout.write('\r%d/%d' % (cnt + 1, l))
+            stdout.write('\r%d/%d' % (cnt + 1, length_of_list))
             stdout.flush()
 
 
 def _dump_json_data(path, data):
     with open(path, 'w') as f:
         json.dump(data, f, indent=2, sort_keys=True, separators=(',', ': '))
-

--- a/tztrout/data_exceptions.py
+++ b/tztrout/data_exceptions.py
@@ -14,41 +14,33 @@ that's *the only* tz id to be returned for tztrout.tz_ids_for_address('US', stat
 """
 
 data_exceptions = {
-
     'all': {
-        'exclude': ['America/Indiana/Tell_City', 'America/Indiana/Knox',
-                    'America/North_Dakota/Beulah', 'America/Indiana/Winamac',
-                    'America/Indiana/Petersburg', 'America/Indiana/Vincennes']
+        'exclude': [
+            'America/Indiana/Tell_City',
+            'America/Indiana/Knox',
+            'America/North_Dakota/Beulah',
+            'America/Indiana/Winamac',
+            'America/Indiana/Petersburg',
+            'America/Indiana/Vincennes',
+        ]
     },
-
     'state:NY': {
-        'exclude': [u'America/Indiana/Winamac', u'America/Indiana/Petersburg',
-                    u'America/Indiana/Vincennes']
+        'exclude': [
+            u'America/Indiana/Winamac',
+            u'America/Indiana/Petersburg',
+            u'America/Indiana/Vincennes',
+        ]
     },
-
     'state:PA': {
-        'exclude': [u'America/Indiana/Winamac', u'America/Indiana/Petersburg',
-                    u'America/Indiana/Vincennes']
+        'exclude': [
+            u'America/Indiana/Winamac',
+            u'America/Indiana/Petersburg',
+            u'America/Indiana/Vincennes',
+        ]
     },
-
-    'state:IN': {
-        'include': ['America/Indiana/Indianapolis']
-    },
-
-    'city:el paso': {
-        'include': ['America/Denver']
-    },
-
-    'areacode:915': {
-        'include': ['America/Denver']
-    },
-
-    'areacode:901': {
-        'include': ['America/Chicago']
-    },
-
-    'areacode:202': {
-        'include': ['America/New_York']
-    }
-
+    'state:IN': {'include': ['America/Indiana/Indianapolis']},
+    'city:el paso': {'include': ['America/Denver']},
+    'areacode:915': {'include': ['America/Denver']},
+    'areacode:901': {'include': ['America/Chicago']},
+    'areacode:202': {'include': ['America/New_York']},
 }


### PR DESCRIPTION
Supersedes #25 

This PR adds `black`, `flake8`, and `isort` to `tz-trout` for static-code-analysis in CircleCI.

I took most of `setup.cfg` and `pyproject.toml` from limitlion and tasktiger and I split out the black, flake8, and isort commands into their own steps (as mentioned in #25) so we can easily tell what's failing if necessary.

I also added a `python-3.6` job as requested in #25, so we can test `tz-trout` against python-3.6