### PR TITLE
Use TimezoneFinder to generate us_zips_to_tz_ids mapping instead of using timezone offsets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ workflows:
   workflow:
     jobs:
       - static-code-analysis
-      - test-3.5
       - test-3.6
 
 defaults: &defaults
@@ -38,11 +37,6 @@ jobs:
     - run:
         name: Isort
         command: isort -rc -c .
-    
-  test-3.5:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.5
   
   test-3.6:
       <<: *defaults

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This library tries to solve the common problem of figuring out what time zone
 a specific address or a phone number is in. It does so by using several
-mappings that are generated with the help of pytz (http://pytz.sourceforge.net/)
-and pyzipcode (https://github.com/fdintino/pyzipcode).
+mappings that are generated with the help of [pytz](http://pytz.sourceforge.net/),
+[pyzipcode](https://github.com/fdintino/pyzipcode), and [TimezoneFinder](https://github.com/MrMinimal64/timezonefinder)
 
 Current version is fairly accurate for the United States, Canada, Australia, and
 countries which fit within a single time zone.
@@ -13,6 +13,8 @@ Vocabulary used in this library:
 * America/Los_Angeles - time zone identifier
 * UTC-07:00 or -420 - UTC offset (the latter given in minutes)
 * DST - Daylight Saving Time
+
+Starting in `v1.0.0`, this library requires Python version 3.6 or above.
 
 #### Examples
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 pytz==2019.1
 phonenumbers==8.10.10
 python-dateutil==2.8.0
-timezonefinder==4.2.0
+timezonefinder==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 pytz==2019.1
 phonenumbers==8.10.10
 python-dateutil==2.8.0
+timezonefinder==4.2.0

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='tz-trout',
-    version='0.2.2',
+    version='1.0.0',
     url='http://github.com/closeio/tz-trout',
     license='MIT',
     author='Close.io',

--- a/tests/test_tztrout.py
+++ b/tests/test_tztrout.py
@@ -525,7 +525,6 @@ class TestTZIdsForAddress:
             ('96079', 'PT'),
             ('97470', 'PT'),
             ('98109', 'PT'),
-            ('99950', 'PT'),
         ],
     )
     def test_tz_names_for_zipcode_only_addresses(

--- a/tests/test_tztrout.py
+++ b/tests/test_tztrout.py
@@ -5,7 +5,10 @@ from mock import patch
 
 import tztrout
 
-US_CA_TZ_NAMES = ['PT', 'MT', 'CT', 'ET', 'AT']
+current_alaska_tz_name = (
+    'AKDT' if tztrout.tz_ids_for_tz_name('AKDT') else 'AKST'
+)
+US_CA_TZ_NAMES = ['PT', 'MT', 'CT', 'ET', 'AT', current_alaska_tz_name]
 AU_TZ_NAMES = ['AWT', 'ACT', 'AET']
 
 
@@ -525,6 +528,7 @@ class TestTZIdsForAddress:
             ('96079', 'PT'),
             ('97470', 'PT'),
             ('98109', 'PT'),
+            ('99950', current_alaska_tz_name),
         ],
     )
     def test_tz_names_for_zipcode_only_addresses(

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -6,9 +6,9 @@ from sys import stdout
 
 import pytz
 from pyzipcode import ZipCode, ZipCodeDatabase
+from timezonefinder import TimezoneFinder
 
 from tztrout.data_exceptions import data_exceptions
-from timezonefinder import TimezoneFinder
 
 # paths to the data files
 basepath = os.path.dirname(os.path.abspath(__file__))

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -224,21 +224,6 @@ class TroutData(object):
             dt -= datetime.timedelta(**self.TD_STEP)
         return offsets
 
-    def _experiences_dst(self, tz):
-        """Check if the time zone identifier has experienced the DST in the
-        recent years.
-        """
-        dt = datetime.datetime.utcnow()
-        while dt.year > self.RECENT_YEARS_START:
-            try:
-                dst = tz.dst(dt).total_seconds()
-                if dst:
-                    return True
-            except (pytz.NonExistentTimeError, pytz.AmbiguousTimeError):
-                pass
-            dt -= datetime.timedelta(**self.TD_STEP)
-        return False
-
     def _get_latest_tz_names(self, tz):
         """Get the recent time zone names for a given time zone identifier."""
         dt = datetime.datetime.utcnow()
@@ -255,19 +240,6 @@ class TroutData(object):
                 pass
             dt -= datetime.timedelta(**self.TD_STEP)
         return tz_names
-
-    def _get_tz_identifiers_for_offset(self, country, offset):
-        """Get all the possible time zone identifiers for a given UTC offset.
-        Ignore the DST offsets.
-        """
-        identifiers = pytz.country_timezones.get(country)
-        ids = []
-        for id in identifiers:
-            tz = pytz.timezone(id)
-            tz_offset = self._get_latest_non_dst_offset(tz)
-            if offset == tz_offset:
-                ids.append(id)
-        return ids
 
     def _get_tz_identifiers_for_us_zipcode(self, zipcode):
         """Get all the possible identifiers for a given US zip code."""

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -250,10 +250,10 @@ class TroutData(object):
             else:
                 return
 
-        # Find all the TZ identifiers for a Zipcode given the latitude and longitude
+        # Find the TZ identifier for a Zipcode given its latitude and longitude
         # using the TimezoneFinder library
-        tz_ids = tf.timezone_at(lng=zipcode.longitude, lat=zipcode.latitude)
-        return [tz_ids]
+        tz_id = tf.timezone_at(lng=zipcode.longitude, lat=zipcode.latitude)
+        return [tz_id]
 
     def generate_zip_to_tz_id_map(self):
         """Generate the map of US zip codes to time zone identifiers. The

--- a/tztrout/data.py
+++ b/tztrout/data.py
@@ -8,6 +8,7 @@ import pytz
 from pyzipcode import ZipCode, ZipCodeDatabase
 
 from tztrout.data_exceptions import data_exceptions
+from timezonefinder import TimezoneFinder
 
 # paths to the data files
 basepath = os.path.dirname(os.path.abspath(__file__))
@@ -57,6 +58,8 @@ AU_MAP = {
 ASIA_MAP = {
     'PST': 'PHT',
 }
+
+tf = TimezoneFinder()
 
 
 def deduplicator():
@@ -275,20 +278,10 @@ class TroutData(object):
             else:
                 return
 
-        # Find all the TZ identifiers with a non-DST offset of zipcode.timezone
-        tz_ids = self._get_tz_identifiers_for_offset(
-            'US', datetime.timedelta(hours=zipcode.timezone)
-        )
-
-        # For each of the found identifiers, cross-reference the DST data from
-        # pytz and pyzipcode and only include the identifier if they match
-        ret_ids = []
-        for id in tz_ids:
-            tz = pytz.timezone(id)
-            tz_experiences_dst = self._experiences_dst(tz)
-            if tz_experiences_dst == bool(zipcode.dst):
-                ret_ids.append(id)
-        return ret_ids
+        # Find all the TZ identifiers for a Zipcode given the latitude and longitude
+        # using the TimezoneFinder library
+        tz_ids = tf.timezone_at(lng=zipcode.longitude, lat=zipcode.latitude)
+        return [tz_ids]
 
     def generate_zip_to_tz_id_map(self):
         """Generate the map of US zip codes to time zone identifiers. The

--- a/tztrout/data/us_zips_to_tz_ids.json
+++ b/tztrout/data/us_zips_to_tz_ids.json
@@ -60948,271 +60948,271 @@
     "America/Indiana/Indianapolis"
   ],
   "46301": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46302": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46303": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46304": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46305": [
     "America/Indiana/Indianapolis"
   ],
   "46307": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46308": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46310": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46311": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46312": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46319": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46320": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46321": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46322": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46323": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46324": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46325": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46327": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46332": [
     "America/Indiana/Indianapolis"
   ],
   "46340": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46341": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46342": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46345": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46346": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46347": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46348": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46349": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46350": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46352": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46355": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46356": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46360": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46361": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46365": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46366": [
     "America/Indiana/Indianapolis"
   ],
   "46368": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46369": [
     "America/Indiana/Indianapolis"
   ],
   "46371": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46372": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46373": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46374": [
     "America/Indiana/Indianapolis"
   ],
   "46375": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46376": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46377": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46379": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46380": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46381": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46382": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46383": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46384": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46385": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46386": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46390": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46391": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46392": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46393": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46394": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46401": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46402": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46403": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46404": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46405": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46406": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46407": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46408": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46409": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46410": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46411": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "46415": [
     "America/Indiana/Indianapolis"
@@ -62020,8 +62020,8 @@
     "America/Indiana/Indianapolis"
   ],
   "47011": [
-    "America/Indiana/Vevay",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Vevay"
   ],
   "47012": [
     "America/Indiana/Indianapolis"
@@ -62037,12 +62037,12 @@
     "America/New_York"
   ],
   "47019": [
-    "America/Indiana/Vevay",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Vevay"
   ],
   "47020": [
-    "America/Indiana/Vevay",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Vevay"
   ],
   "47021": [
     "America/Indiana/Indianapolis"
@@ -62087,8 +62087,8 @@
     "America/Indiana/Indianapolis"
   ],
   "47038": [
-    "America/Indiana/Vevay",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Vevay"
   ],
   "47039": [
     "America/Indiana/Indianapolis"
@@ -62104,12 +62104,12 @@
     "America/Indiana/Indianapolis"
   ],
   "47043": [
-    "America/Indiana/Vevay",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Vevay"
   ],
   "47045": [
-    "America/Indiana/Vevay",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Vevay"
   ],
   "47048": [
     "America/Indiana/Indianapolis"
@@ -62122,123 +62122,123 @@
     "America/Indiana/Indianapolis"
   ],
   "47093": [
-    "America/Indiana/Vevay",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Vevay"
   ],
   "47102": [
     "America/Indiana/Indianapolis"
   ],
   "47104": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47106": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47107": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47108": [
     "America/Indiana/Indianapolis"
   ],
   "47110": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47111": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47112": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47114": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47115": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47116": [
-    "America/Indiana/Marengo",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Marengo"
   ],
   "47117": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47118": [
-    "America/Indiana/Marengo",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Marengo"
   ],
   "47119": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47120": [
     "America/Indiana/Indianapolis"
   ],
   "47122": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47123": [
-    "America/Indiana/Marengo",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Marengo"
   ],
   "47124": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47125": [
     "America/Indiana/Indianapolis"
   ],
   "47126": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47128": [
     "America/Indiana/Indianapolis"
   ],
   "47129": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47130": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47131": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47132": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47133": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47134": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47135": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47136": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47137": [
-    "America/Indiana/Marengo",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Marengo"
   ],
   "47138": [
     "America/Indiana/Indianapolis"
@@ -62247,71 +62247,71 @@
     "America/Indiana/Indianapolis"
   ],
   "47140": [
-    "America/Indiana/Marengo",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Marengo"
   ],
   "47141": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47142": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47143": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47144": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47145": [
-    "America/Indiana/Marengo",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Marengo"
   ],
   "47146": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47147": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47150": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47151": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47160": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47161": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47162": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47163": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47164": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47165": [
     "America/Indiana/Indianapolis"
   ],
   "47166": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47167": [
     "America/Indiana/Indianapolis"
@@ -62323,28 +62323,28 @@
     "America/Indiana/Indianapolis"
   ],
   "47172": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47174": [
-    "America/Indiana/Marengo",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Marengo"
   ],
   "47175": [
-    "America/Indiana/Marengo",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Indiana/Marengo"
   ],
   "47177": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47190": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47199": [
-    "America/Kentucky/Louisville",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Kentucky/Louisville"
   ],
   "47201": [
     "America/Indiana/Indianapolis"
@@ -62698,8 +62698,8 @@
     "America/Indiana/Indianapolis"
   ],
   "47412": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47420": [
     "America/Indiana/Indianapolis"
@@ -62864,8 +62864,8 @@
     "America/Indiana/Indianapolis"
   ],
   "47523": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47524": [
     "America/Indiana/Indianapolis"
@@ -62883,8 +62883,8 @@
     "America/Indiana/Indianapolis"
   ],
   "47531": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47532": [
     "America/Indiana/Indianapolis"
@@ -62893,12 +62893,12 @@
     "America/Indiana/Indianapolis"
   ],
   "47536": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47537": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47541": [
     "America/Indiana/Indianapolis"
@@ -62919,22 +62919,22 @@
     "America/Indiana/Indianapolis"
   ],
   "47550": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47551": [
     "America/Indiana/Indianapolis"
   ],
   "47552": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47553": [
     "America/Indiana/Indianapolis"
   ],
   "47556": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47557": [
     "America/Indiana/Indianapolis"
@@ -62970,15 +62970,15 @@
     "America/Indiana/Indianapolis"
   ],
   "47577": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47578": [
     "America/Indiana/Indianapolis"
   ],
   "47579": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47580": [
     "America/Indiana/Indianapolis"
@@ -63014,293 +63014,293 @@
     "America/Indiana/Indianapolis"
   ],
   "47601": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47610": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47611": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47612": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47613": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47614": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47615": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47616": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47617": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47618": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47619": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47620": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47625": [
     "America/Indiana/Indianapolis"
   ],
   "47629": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47630": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47631": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47633": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47634": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47635": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47637": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47638": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47639": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47640": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47647": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47648": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47649": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47654": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47660": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47665": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47666": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47667": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47670": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47671": [
     "America/Indiana/Indianapolis"
   ],
   "47672": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47683": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47701": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47702": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47703": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47704": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47705": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47706": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47708": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47710": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47711": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47712": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47713": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47714": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47715": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47716": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47718": [
     "America/Indiana/Indianapolis"
   ],
   "47719": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47720": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47721": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47722": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47724": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47725": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47727": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47728": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47729": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47730": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47731": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47732": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47733": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47734": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47735": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47736": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47737": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47739": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47740": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47741": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47744": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47747": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47750": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47765": [
     "America/Indiana/Indianapolis"
@@ -63528,8 +63528,8 @@
     "America/Indiana/Indianapolis"
   ],
   "47922": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47923": [
     "America/Indiana/Indianapolis"
@@ -63586,8 +63586,8 @@
     "America/Indiana/Indianapolis"
   ],
   "47943": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47944": [
     "America/Indiana/Indianapolis"
@@ -63596,8 +63596,8 @@
     "America/Indiana/Indianapolis"
   ],
   "47948": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47949": [
     "America/Indiana/Indianapolis"
@@ -63606,8 +63606,8 @@
     "America/Indiana/Indianapolis"
   ],
   "47951": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47952": [
     "America/Indiana/Indianapolis"
@@ -63634,12 +63634,12 @@
     "America/Indiana/Indianapolis"
   ],
   "47963": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47964": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47965": [
     "America/Indiana/Indianapolis"
@@ -63672,12 +63672,12 @@
     "America/Indiana/Indianapolis"
   ],
   "47977": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47978": [
-    "America/Chicago",
-    "America/Indiana/Indianapolis"
+    "America/Indiana/Indianapolis",
+    "America/Chicago"
   ],
   "47980": [
     "America/Indiana/Indianapolis"


### PR DESCRIPTION
Depends on #27 

This PR makes it so that when we generate the `us_zips_to_tz_ids.json` file, we use the [TimezoneFinder library](https://github.com/MrMinimal64/timezonefinder) that relies on a Zipcode's latitude and longitude coordinates to find a more precise timezone, instead of relying on the Zipcode's `timezone` attribute (its UTC offset) that existed in `pyzipcode` but does not exist in more current datasets. 

Given that TimezoneFinder returns a more precise timezone, we no longer need to return every timezone for a UTC offset as part of the mapping from zipcodes to tz_ids. This allows us to get rid of the `_experiences_dst` and `_get_tz_identifiers_for_offset` methods. 

Lastly, the more precise zipcode mapping from TimezoneFinder exposed an issue with the last test added in #27 where the offset-based mapping said that `99950` was in PT, but in actuality it's in Alaskan Time. So, because Alaskan Time does not have a convenient abbreviation (like AKT), to fix the test, I use `tz_ids_for_tz_name` to find out if Alaskan Time is currently `AKDT` or `AKST` and then add that timezone to the `US_CA_TZ_NAMES` array to test `99950`.

This is the last step required for #12 before we can begin to integrate the new data set. 