### PR TITLE
Add python_requires to setup.py and bump version number, so that we don't allow people on < 3.6 to download the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='tz-trout',
-    version='1.0.0',
+    version='1.0.1',
     url='http://github.com/closeio/tz-trout',
     license='MIT',
     author='Close.io',
@@ -20,6 +20,7 @@ setup(
     ],
     packages=['tztrout',],
     package_data={'tztrout': ['data/*']},
+    python_requires='>=3.6',
     install_requires=['phonenumbers>=8.3.0', 'python-dateutil', 'pytz',],
     tests_require=['mock', 'pytest'],
 )


### PR DESCRIPTION
In testing `1.0.0` on PyPI, i noticed that it still lets me download 1.0.0 on py2. This PR adds python requires to setup.py to stop that. 

