### PR TITLE
Add Kentucky Eastern exceptions

### DIFF
--- a/tztrout/data_exceptions.py
+++ b/tztrout/data_exceptions.py
@@ -42,4 +42,7 @@ data_exceptions = {
     'areacode:915': {'include': ['America/Denver']},
     'areacode:901': {'include': ['America/Chicago']},
     'areacode:202': {'include': ['America/New_York']},
+    'areacode:502': {'include': ['America/New_York']},  # eastern Kentucky
+    'areacode:606': {'include': ['America/New_York']},  # eastern Kentucky
+    'areacode:859': {'include': ['America/New_York']},  # eastern Kentucky
 }

--- a/tztrout/data_exceptions.py
+++ b/tztrout/data_exceptions.py
@@ -43,6 +43,5 @@ data_exceptions = {
     'areacode:901': {'include': ['America/Chicago']},
     'areacode:202': {'include': ['America/New_York']},
     'areacode:502': {'include': ['America/New_York']},  # eastern Kentucky
-    'areacode:606': {'include': ['America/New_York']},  # eastern Kentucky
     'areacode:859': {'include': ['America/New_York']},  # eastern Kentucky
 }


### PR DESCRIPTION
The eastern part of Kentucky is in Eastern timezone.

https://en.wikipedia.org/wiki/List_of_Kentucky_area_codes
https://www.allareacodes.com/502
https://www.allareacodes.com/606
https://www.allareacodes.com/859