### PR TITLE
Fix data generation zip codes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
 
       - name: Verify timezone data is up to date
         run:
-          python regenerate_data.py
+          # --skip-geonames-download keeps the check deterministic
+          python regenerate_data.py --skip-geonames-download
 
       - name: Check for uncommitted changes
         shell: bash

--- a/generate_zipcode_data.py
+++ b/generate_zipcode_data.py
@@ -28,11 +28,19 @@ def _get_latest_us_zipcode_data():
         return us_zipcode_zip_file.open(US_ZIPCODE_TXT_FILE_NAME).readlines()
 
 
-def generate_us_zipcode_data():
+def generate_us_zipcode_data(skip_download=False):
     """
     Generate a list of US zipcode data from the txt file in the latest
     Geonames.org database and save it as a JSON file.
+
+    Pass skip_download=True to use the already-committed us_zipcode_data.json instead of fetching
+    fresh data from Geonames.org.
     """
+    if skip_download:
+        print("Skipping Geonames download, using existing us_zipcode_data.json")
+        return
+
+    print("Downloading Geonames data...")
     us_zipcode_data = []
     us_zipcode_txt_file_data = _get_latest_us_zipcode_data()
     for line in us_zipcode_txt_file_data:

--- a/generate_zipcode_data.py
+++ b/generate_zipcode_data.py
@@ -37,7 +37,9 @@ def generate_us_zipcode_data(skip_download=False):
     fresh data from Geonames.org.
     """
     if skip_download:
-        print("Skipping Geonames download, using existing us_zipcode_data.json")
+        print(
+            "Skipping Geonames download, using existing us_zipcode_data.json"
+        )
         return
 
     print("Downloading Geonames data...")

--- a/regenerate_data.py
+++ b/regenerate_data.py
@@ -2,6 +2,10 @@
 """
 Run this script when you upgrade dependencies.
 Commit changes after the run.
+
+Pass --skip-geonames-download to skip re-downloading the Geonames.org US
+zipcode source data and use the already-committed us_zipcode_data.json instead
+(used by CI to keep the check deterministic).
 """
 
 import sys
@@ -12,7 +16,8 @@ sys.path.append(".")
 
 
 if __name__ == "__main__":
-    generate_us_zipcode_data()
+    generate_us_zipcode_data(skip_download="--skip-geonames-download" in sys.argv)
+
     from tztrout import td
 
     td.generate_tz_name_to_tz_id_map()

--- a/regenerate_data.py
+++ b/regenerate_data.py
@@ -16,7 +16,9 @@ sys.path.append(".")
 
 
 if __name__ == "__main__":
-    generate_us_zipcode_data(skip_download="--skip-geonames-download" in sys.argv)
+    generate_us_zipcode_data(
+        skip_download="--skip-geonames-download" in sys.argv
+    )
 
     from tztrout import td
 

--- a/tests/test_tztrout.py
+++ b/tests/test_tztrout.py
@@ -621,6 +621,7 @@ PACIFIC_IDS = {
 
 
 class TestTZIdsForTZName:
+    @patch("datetime.datetime", FakeDateTime)
     @pytest.mark.parametrize(
         ("tz_name", "tz_ids"),
         [
@@ -630,8 +631,16 @@ class TestTZIdsForTZName:
         ],
     )
     def test_ids_for_tz_name(self, tz_name, tz_ids):
+        FakeDateTime.set_utcnow(datetime.datetime(2024, 1, 15))
         ids = tztrout.tz_ids_for_tz_name(tz_name)
         assert set(ids) == tz_ids
+
+    @patch("datetime.datetime", FakeDateTime)
+    def test_ids_for_ist_summer(self):
+        # In summer, Ireland uses IST (DST); Israel uses IDT instead.
+        FakeDateTime.set_utcnow(datetime.datetime(2024, 7, 15))
+        ids = tztrout.tz_ids_for_tz_name("IST")
+        assert set(ids) == {"Asia/Kolkata", "Europe/Dublin", "Asia/Calcutta"}
 
 
 class TestLocalTimeForAddress:


### PR DESCRIPTION
This PR solves issues wiht generating data not being deterministic:

- We don't download new data in CI, we just use the  commited geonames data.

c3fec0310632d73e3d4d9c9560607108406019e7

- The tests now freeze a datetime so they are more consistent 

aa650e88f3f9380d0df43ad9c75e31b8a90b08f6


---

Fixes https://github.com/closeio/tz-trout/issues/228